### PR TITLE
update default dimensions

### DIFF
--- a/extension-src/bmap/BMapCoordSys.js
+++ b/extension-src/bmap/BMapCoordSys.js
@@ -35,7 +35,7 @@ function BMapCoordSys(bmap, api) {
     this._projection = new BMap.MercatorProjection();
 }
 
-BMapCoordSys.prototype.dimensions = ['lng', 'lat'];
+BMapCoordSys.prototype.dimensions = ['lng', 'lat', 'value'];
 
 BMapCoordSys.prototype.setZoom = function (zoom) {
     this._zoom = zoom;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing



### What does this PR do?

fix issue 11528



### Fixed issues

bmap tooltip show the lat not the value


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

modify the BMapCoordSys.prototype.dimensions = ['lng', 'lat'] to 
BMapCoordSys.prototype.dimensions = ['lng', 'lat', 'value']



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
